### PR TITLE
Update add-on config and startup to use bashio, bump version to 2.1.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,13 +28,18 @@ Bridge für Warema WMS Geräte mit MQTT-Unterstützung – kompatibel mit aktuel
 
 Passe die Optionen im Add-on an:
 
-| Option         | Beschreibung                        | Standardwert                    |
-|----------------|-------------------------------------|---------------------------------|
-| MQTT_SERVER    | Adresse des MQTT-Brokers            | mqtt://core-mosquitto:1883      |
-| MQTT_USER      | MQTT Benutzername                   | (leer)                          |
-| MQTT_PASSWORD  | MQTT Passwort                       | (leer)                          |
-| SERIAL_PORT    | Pfad zum USB-Stick                  | /dev/ttyUSB0                    |
-| LOG_LEVEL      | Log-Level                           | info                            |
+| Option           | Beschreibung                        | Standardwert                    |
+|------------------|-------------------------------------|---------------------------------|
+| mqtt_server      | Adresse des MQTT-Brokers            | mqtt://core-mosquitto:1883      |
+| mqtt_user        | MQTT Benutzername                   | (leer)                          |
+| mqtt_password    | MQTT Passwort                       | (leer)                          |
+| log_level        | Log-Level                           | info                            |
+| wms_serial_port  | Pfad zum USB-Stick                  | /dev/ttyUSB0                    |
+| wms_key          | WMS-Schlüssel                       | (leer)                          |
+| wms_pan_id       | WMS PAN ID                          | FFFF                            |
+| wms_channel      | WMS Kanal                           | 17                              |
+| ignored_devices  | Kommagetrennte Geräte-IDs ignorieren| (leer)                          |
+| force_devices    | Kommagetrennte Geräte-IDs erzwingen | (leer)                          |
 
 ## Entwicklung & Standalone-Nutzung
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Warema WMS Bridge
-version: "2.0.0"
+version: "2.1.0"
 slug: addon-warema-bridge
 description: "Bridge for Warema WMS devices with MQTT support"
 arch:
@@ -20,13 +20,26 @@ devices:
   - /dev/ttyUSB0
 
 options:
-  wms_serial_port: null
+  mqtt_server: "mqtt://core-mosquitto:1883"
+  mqtt_user: ""
+  mqtt_password: ""
+  log_level: "info"
+  wms_serial_port: "/dev/ttyUSB0"
+  wms_key: ""
+  wms_pan_id: "FFFF"
+  wms_channel: 17
+  ignored_devices: ""
+  force_devices: ""
 
 schema:
-  wms_key: str?
+  mqtt_server: str?
+  mqtt_user: str?
+  mqtt_password: password?
+  log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  wms_serial_port: device(subsystem=tty)
+  wms_key: password?
   wms_pan_id: str?
   wms_channel: int?
-  wms_serial_port: device(subsystem=tty)
   ignored_devices: str?
   force_devices: str?
 

--- a/repository.json
+++ b/repository.json
@@ -4,5 +4,5 @@
   "maintainer": "chha25",
   "slug": "addon-warema-bridge",
   "type": "addon",
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,32 @@
-#!/bin/sh
+#!/usr/bin/with-contenv bashio
 
-set -e
+set -euo pipefail
 
-MQTT_SERVER=${MQTT_SERVER:-"mqtt://core-mosquitto:1883"}
-SERIAL_PORT=${SERIAL_PORT:-"/dev/ttyUSB0"}
-LOG_LEVEL=${LOG_LEVEL:-"info"}
+MQTT_SERVER="$(bashio::config 'mqtt_server')"
+MQTT_USER="$(bashio::config 'mqtt_user')"
+MQTT_PASSWORD="$(bashio::config 'mqtt_password')"
+SERIAL_PORT="$(bashio::config 'wms_serial_port')"
+LOG_LEVEL="$(bashio::config 'log_level')"
+WMS_KEY="$(bashio::config 'wms_key')"
+WMS_PAN_ID="$(bashio::config 'wms_pan_id')"
+WMS_CHANNEL="$(bashio::config 'wms_channel')"
+IGNORED_DEVICES="$(bashio::config 'ignored_devices')"
+FORCE_DEVICES="$(bashio::config 'force_devices')"
+
+MQTT_SERVER="${MQTT_SERVER:-mqtt://core-mosquitto:1883}"
+SERIAL_PORT="${SERIAL_PORT:-/dev/ttyUSB0}"
+LOG_LEVEL="${LOG_LEVEL:-info}"
+
+export MQTT_SERVER
+export MQTT_USER
+export MQTT_PASSWORD
+export SERIAL_PORT
+export LOG_LEVEL
+export WMS_KEY
+export WMS_PAN_ID
+export WMS_CHANNEL
+export IGNORED_DEVICES
+export FORCE_DEVICES
 
 echo "Starting Warema WMS Bridge addon..."
 echo "MQTT_SERVER=${MQTT_SERVER}"


### PR DESCRIPTION
### Motivation
- Auf die neue Home Assistant Add-on-Konfiguration umstellen und Metadaten-Version anheben, damit die Add-on-Optionen sauber über das Add-on UI verfügbar sind.
- Startup-Skript robuster und sicherer machen, indem Add-on-Optionen via `bashio` gelesen und als Laufzeit-Umgebungsvariablen gesetzt werden.
- Konfigurations-Defaults, Schema und Dokumentation erweitern, um sensible Werte wie Keys/Passwörter korrekt zu behandeln.

### Description
- Erhöhe die Add-on-Version in `config.yaml` und `repository.json` auf `2.1.0`.
- Erweitere `config.yaml` mit neuen `options`-Defaults und einem präziseren `schema` (`mqtt_server`, `mqtt_user`, `mqtt_password` als `password?`, `log_level` mit erlaubten Werten, `wms_key` als `password?`, u.a.).
- Ersetze das Startskript `run.sh` durch ein `bashio`-basiertes Script (`#!/usr/bin/with-contenv bashio`) und aktiviere sichere Shell-Flags (`set -euo pipefail`), lese Add-on-Optionen mit `bashio::config` und exportiere sie als Umgebungsvariablen für die Node.js-Bridge.
- Aktualisiere `Readme.md`, um die neuen Option-Namen, Defaults und Beschreibungen zu dokumentieren.

### Testing
- Es wurden keine automatisierten Tests ausgeführt für diese Änderung.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a519730d88328966e5cd94a79d008)