### PR TITLE
Add configurable structured logging for bridge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,14 @@ Passe die Optionen im Add-on an:
 | ignored_devices  | Kommagetrennte Geräte-IDs ignorieren| (leer)                          |
 | force_devices    | Kommagetrennte Geräte-IDs erzwingen | (leer)                          |
 
+### Logging
+
+Das Add-on unterstützt konfigurierbares Logging über die Option `log_level`.
+
+Unterstützte Level: `trace`, `debug`, `info`, `notice`, `warning`, `error`, `fatal`
+
+Das Bridge-Logging wird einheitlich mit Zeitstempel und Level ausgegeben (z.B. `[2026-01-01T12:00:00.000Z] [INFO] Connected to MQTT`).
+
 ## Entwicklung & Standalone-Nutzung
 
 ### Docker (Standalone)


### PR DESCRIPTION
### Motivation

- Provide a clean, centralized and level-based logging system so the bridge output can be controlled via the add-on configuration.
- Replace ad-hoc `console.log` usage with structured logs including ISO timestamps and level prefixes for more consistent observability.
- Document logging behavior in the add-on README and ensure the add-on option `log_level` controls runtime verbosity.

### Description

- Add a small level mapping and resolver plus a `log(level, message, ...)` helper in `warema-bridge/rootfs/srv/bridge.js` and derive the active level from the `LOG_LEVEL` environment variable.
- Route existing bridge logs (device registration, scanning, callback events, MQTT connect/error, unknown messages) through the new logger and suppress messages below the configured priority, while emitting `error`/`fatal` to `console.error`.
- Keep the add-on-config control via `LOG_LEVEL` (already exported by `run.sh`) and format logs as `[ISO_TIMESTAMP] [LEVEL] message`.
- Add a `### Logging` section to `Readme.md` describing the `log_level` option, supported levels and example output.

### Testing

- Ran `node --check bridge.js` in `warema-bridge/rootfs/srv` and it completed successfully.
- Attempted `npm test` in `warema-bridge/rootfs/srv`, but it failed in this environment because the test runner is not available (`sh: 1: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ae59bfa848328a4c6c2dccb74a145)