### PR TITLE
Run npm start from /srv to fix ENOENT on addon start

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -40,4 +40,4 @@ if [ ! -e "${SERIAL_PORT}" ] ; then
   done
 fi
 
-exec npm run start
+exec npm --prefix /srv run start


### PR DESCRIPTION
### Motivation
- The add-on failed on startup with `npm error enoent Could not read package.json` because `npm run start` was executed from the s6 service working directory (`/run/s6/legacy-services/...`) instead of the application directory containing `package.json`.

### Description
- Update `run.sh` to invoke the start script with `npm --prefix /srv run start` so `npm` uses `/srv` as the project root regardless of the current working directory.
- This change ensures `package.json` under `warema-bridge/rootfs/srv` is discovered even when the service is launched from a different folder.

### Testing
- Performed a syntax check with `bash -n run.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce53290248328bd4793c2170b7086)