### PR TITLE
Add CHANGELOG.md and GitHub URL to config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+Alle nennenswerten Änderungen an diesem Home Assistant Add-on werden in dieser Datei dokumentiert.
+
+## 2.1.1
+
+- Aktualisierung auf Node.js 20 (LTS) als Laufzeitbasis.
+- Verbesserte Home Assistant Add-on Kompatibilität und aktualisierte Add-on Metadaten.
+- Stabilitäts- und Logging-Verbesserungen für den Betrieb mit MQTT und WMS-USB-Stick.
+
+## 2.1.0
+
+- Überarbeitete Konfiguration für den Betrieb mit aktuellen Home Assistant Versionen.
+- Verbesserungen bei der Geräteerkennung und MQTT-Integration.
+
+## 2.0.0
+
+- Größere Modernisierung des Add-ons inklusive Architektur- und Laufzeitanpassungen.
+- Vorbereitung für Multi-Arch-Builds und robusteren Betrieb im Add-on Umfeld.
+
+## Weitere Informationen
+
+Weitere Informationen, Quellcode und Support:
+
+- GitHub: https://github.com/chha25/addon-warema-bridge

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ name: Warema WMS Bridge
 version: "2.1.1"
 slug: addon-warema-bridge
 description: "Bridge for Warema WMS devices with MQTT support"
+url: "https://github.com/chha25/addon-warema-bridge"
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
### Motivation
- Bereitstellung einer sichtbaren Changelog-Datei für die Anzeige im Home Assistant Add-on, damit Nutzer Änderungen und Versionen direkt einsehen können.
- Ermöglichen eines direkten Verweises auf das GitHub-Repository in der Add-on-Oberfläche über die `url`-Metadaten für „Weitere Informationen“. 

### Description
- Neue Datei `CHANGELOG.md` hinzugefügt mit Versionseinträgen für `2.1.1`, `2.1.0` und `2.0.0` sowie einem Abschnitt „Weitere Informationen“ mit dem GitHub-Link. 
- `config.yaml` um das Feld `url: "https://github.com/chha25/addon-warema-bridge"` ergänzt, damit Home Assistant unter „More info“ auf das Repository verlinken kann. 
- Änderungen beschränken sich auf das Hinzufügen der Changelog-Datei und das Aktualisieren der Add-on-Metadaten. 

### Testing
- `git diff --check` ausgeführt und es wurden keine Probleme gemeldet (erfolgreich). 
- Versuch einer YAML-Validierung mit Python (`yaml`-Modul) schlug fehl, da das `PyYAML`-Paket in der Umgebung nicht installiert ist (fehlgeschlagen).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cebcb41308328a8a8e7a8230dfec0)