### PR TITLE
Avoid nested /init to prevent s6-overlay pid1 error; bump to 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Alle nennenswerten Änderungen an diesem Home Assistant Add-on werden in dieser Datei dokumentiert.
 
+## 2.1.3
+
+- Fix: Entferntes `CMD ["/init"]` im Add-on-Dockerfile, damit `/init` nicht als Unterprozess gestartet wird (Fehler `s6-overlay-suexec: fatal: can only run as pid 1`).
+
 ## 2.1.2
 
 - Fix #14: Doppelstart beseitigt und Start auf Home-Assistant-Standard (`/init` + `services.d`) umgestellt.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,3 @@ COPY warema-bridge/rootfs/ /
 
 RUN chmod a+x /etc/services.d/warema-bridge/run
 
-CMD ["/init"]

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Warema WMS Bridge
-version: "2.1.2"
+version: "2.1.3"
 slug: addon-warema-bridge
 description: "Bridge for Warema WMS devices with MQTT support"
 url: "https://github.com/chha25/addon-warema-bridge"


### PR DESCRIPTION
### Motivation
- Prevent the runtime error `s6-overlay-suexec: fatal: can only run as pid 1` which occurs when `/init` is invoked as a subprocess rather than remaining the single PID 1 init process. 
- Bump the add-on version to reflect the startup-fix and record the change in the changelog.

### Description
- Remove the explicit `CMD ["/init"]` from the add-on `Dockerfile` so the base image entrypoint remains the PID 1 init process. 
- Bump `version` to `2.1.3` in `config.yaml`. 
- Add an entry to `CHANGELOG.md` documenting the fix and the `s6-overlay-suexec` error context.

### Testing
- Inspected the image layer changes with `git diff` and confirmed the `CMD ["/init"]` line was removed from `Dockerfile`. 
- Ran `npm --prefix warema-bridge/rootfs/srv ci` to install dependencies and verified `node_modules` is present. 
- Ran `npm --prefix warema-bridge/rootfs/srv test` which failed in this environment due to `jest` not being available (`sh: 1: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0abbd0e108328a7274ac2d1d0bc9f)