### PR TITLE
Fix Home Assistant add-on build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,56 @@
 # Changelog
 
-Alle nennenswerten Änderungen an diesem Home Assistant Add-on werden in dieser Datei dokumentiert.
+All notable changes to this Home Assistant add-on are documented in this file.
+
+## 2.1.5
+
+- Fix #23: Updated the Home Assistant add-on build for the current BuildKit-based build process (`Dockerfile` as the single source of truth).
+- Fix #23: The add-on image now uses `ghcr.io/home-assistant/base:latest` directly, so the build no longer depends on an external `BUILD_FROM` argument.
+- Maintenance: Temporary native build tools are removed from the runtime image after `npm ci --omit=dev`.
+- Maintenance: Updated supported add-on architectures to `amd64` and `aarch64`.
+- Documentation: Added local test steps for the Home Assistant add-on image.
 
 ## 2.1.4
 
-- Wartung: Node.js-LTS-Ausrichtung auf aktuell unterstützte LTS-Linien (22/24, 24 empfohlen) inkl. CI-Matrix.
-- Wartung: Tooling-/Dokumentations-Updates (engines, `.nvmrc`, Standalone-Image, README).
-- Keine Änderungen an der Bridge-Laufzeitlogik.
+- Maintenance: Aligned Node.js LTS support with the currently supported LTS lines (22/24, 24 recommended), including the CI matrix.
+- Maintenance: Tooling and documentation updates (`engines`, `.nvmrc`, standalone image, README).
+- No changes to the bridge runtime logic.
 
 ## 2.1.3
 
-- Fix: Entferntes `CMD ["/init"]` im Add-on-Dockerfile, damit `/init` nicht als Unterprozess gestartet wird (Fehler `s6-overlay-suexec: fatal: can only run as pid 1`).
+- Fix: Removed `CMD ["/init"]` from the add-on Dockerfile so `/init` is not started as a subprocess (error: `s6-overlay-suexec: fatal: can only run as pid 1`).
 
 ## 2.1.2
 
-- Fix #14: Doppelstart beseitigt und Start auf Home-Assistant-Standard (`/init` + `services.d`) umgestellt.
-- Fix #14: HA-Restart-Recovery und MQTT-Topic-Handling für `warema/bridge/state` verbessert.
+- Fix #14: Removed duplicate startup and switched startup to the Home Assistant standard (`/init` + `services.d`).
+- Fix #14: Improved Home Assistant restart recovery and MQTT topic handling for `warema/bridge/state`.
 
 ## 2.1.1
 
-- Aktualisierung auf Node.js 20 (LTS) als Laufzeitbasis.
-- Verbesserte Home Assistant Add-on Kompatibilität und aktualisierte Add-on Metadaten.
-- Stabilitäts- und Logging-Verbesserungen für den Betrieb mit MQTT und WMS-USB-Stick.
+- Updated the runtime base to Node.js 20 (LTS).
+- Improved Home Assistant add-on compatibility and updated add-on metadata.
+- Stability and logging improvements for operation with MQTT and a WMS USB dongle.
 
 ## Unreleased
 
-- Fix #14: Doppelstart durch parallelen service.d-Start entfernt (run.sh wird nur noch einmal gestartet).
-- Fix #14: HA-Restart (`homeassistant/status=online`) setzt Registrierungen zurück, entfernt alte Blind-Registrierungen in der WMS-Library und publiziert Discovery erneut.
-- Fix #14: MQTT Discovery-Configs werden retained publiziert; Bridge-State wird bei Connect aktiv als retained `online` gesetzt.
-- Fix #14: `warema/bridge/state` wird nicht mehr als Gerätetopic interpretiert.
-- Fix #14: MQTT-Command-Subscriptions auf `warema/+/set`, `warema/+/set_position`, `warema/+/set_tilt` eingegrenzt, damit Bridge-Statusmeldungen nicht als Gerätekommando verarbeitet werden.
+- Fix #14: Removed duplicate startup caused by parallel `services.d` startup (`run.sh` is started only once).
+- Fix #14: Home Assistant restart (`homeassistant/status=online`) resets registrations, removes old blind registrations from the WMS library, and republishes discovery.
+- Fix #14: MQTT discovery configs are published as retained messages; bridge state is actively set to retained `online` on connect.
+- Fix #14: `warema/bridge/state` is no longer interpreted as a device topic.
+- Fix #14: MQTT command subscriptions are limited to `warema/+/set`, `warema/+/set_position`, and `warema/+/set_tilt`, so bridge status messages are not processed as device commands.
 
 ## 2.1.0
 
-- Überarbeitete Konfiguration für den Betrieb mit aktuellen Home Assistant Versionen.
-- Verbesserungen bei der Geräteerkennung und MQTT-Integration.
+- Revised configuration for operation with current Home Assistant versions.
+- Improvements to device discovery and MQTT integration.
 
 ## 2.0.0
 
-- Größere Modernisierung des Add-ons inklusive Architektur- und Laufzeitanpassungen.
-- Vorbereitung für Multi-Arch-Builds und robusteren Betrieb im Add-on Umfeld.
+- Major add-on modernization, including architecture and runtime adjustments.
+- Prepared for multi-architecture builds and more robust operation in the add-on environment.
 
-## Weitere Informationen
+## More Information
 
-Weitere Informationen, Quellcode und Support:
+More information, source code, and support:
 
 - GitHub: https://github.com/chha25/addon-warema-bridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
-
-# Install requirements for add-on
+# Install runtime requirements for add-on and native build tooling for serial dependencies.
 RUN apk add --no-cache \
     nodejs \
     npm \
+    libstdc++ \
+  && apk add --no-cache --virtual .build-deps \
     python3 \
     make \
     g++ \
     linux-headers
 
-
-COPY warema-bridge/rootfs/srv/package-lock.json /srv
-COPY warema-bridge/rootfs/srv/package.json /srv
-
 WORKDIR /srv
 
-RUN npm ci --omit=dev
+COPY warema-bridge/rootfs/srv/package-lock.json ./
+COPY warema-bridge/rootfs/srv/package.json ./
+
+RUN npm ci --omit=dev \
+  && apk del --no-cache --purge .build-deps \
+  && rm -rf /root/.npm /root/.cache
 
 COPY warema-bridge/rootfs/ /
 

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Diese Bridge bindet Warema-WMS-Geräte per MQTT in Home Assistant ein und ist mi
 - Kommunikation über MQTT (z. B. mit `core-mosquitto`).
 - Automatische Erkennung und Registrierung von Geräten.
 - Retained Discovery- und Availability-Topics für robustes Recovery nach Home-Assistant-Neustarts.
-- Unterstützung für mehrere Architekturen: `amd64`, `aarch64`, `armv7`, `armhf`.
+- Unterstützung für mehrere Architekturen: `amd64`, `aarch64`.
 - Konfigurierbar über Home-Assistant-Add-on-Optionen.
 - Serielle Verbindung zu einem WMS-USB-Stick.
 
@@ -75,6 +75,22 @@ Hinweise:
 - Falls dein Stick nicht unter `/dev/ttyUSB0` verfügbar ist, passe in `docker-compose.yml` sowohl `devices` als auch `WMS_SERIAL_PORT` an (z. B. `/dev/ttyACM0`).
 - Für Windows: [Verbinden von USB-Geräten](https://learn.microsoft.com/de-de/windows/wsl/connect-usb)
 
+#### Lokaler Test des Home-Assistant-Add-on-Images
+
+Nach Änderungen am `Dockerfile` kann das Home-Assistant-Add-on-Image lokal mit BuildKit geprüft werden:
+
+```sh
+docker buildx build --check .
+docker buildx build --load --tag addon-warema-bridge:local --platform linux/amd64 .
+docker run --rm --entrypoint node addon-warema-bridge:local --check /srv/bridge.js
+docker run --rm --entrypoint node addon-warema-bridge:local -e "require('serialport'); console.log('serialport ok')"
+docker run --rm --entrypoint sh addon-warema-bridge:local -c "command -v g++; command -v make"
+```
+
+Der letzte Befehl sollte keine Ausgabe erzeugen und mit Exit-Code `1` enden. Das ist erwartet und bestätigt, dass die Build-Werkzeuge `g++` und `make` nicht im fertigen Runtime-Image enthalten sind.
+
+Für ARM64 kann statt `linux/amd64` die Plattform `linux/aarch64` verwendet werden. Der vollständige Add-on-Start mit MQTT, `/data/options.json` und echtem USB-Stick sollte weiterhin in Home Assistant oder mit einer passenden lokalen Umgebung geprüft werden.
+
 #### Lokale Entwicklung
 
 1. Node.js 22 oder 24 LTS installieren (empfohlen: aktuellste 24.x) (`^22 || ^24`).
@@ -116,7 +132,7 @@ This bridge integrates Warema WMS devices into Home Assistant via MQTT and is co
 - MQTT communication (e.g. with `core-mosquitto`).
 - Automatic device discovery and registration.
 - Retained discovery and availability topics for robust Home Assistant restart recovery.
-- Multi-architecture support: `amd64`, `aarch64`, `armv7`, `armhf`.
+- Multi-architecture support: `amd64`, `aarch64`.
 - Configurable through Home Assistant add-on options.
 - Serial connection to a WMS USB dongle.
 
@@ -180,6 +196,22 @@ Notes:
 - Make sure `./mosquitto.conf` exists in the project folder (it is included in this repository).
 - If your dongle is not available at `/dev/ttyUSB0`, adjust both `devices` and `WMS_SERIAL_PORT` in `docker-compose.yml` (e.g. `/dev/ttyACM0`).
 - For Windows: [Connect USB devices](https://learn.microsoft.com/windows/wsl/connect-usb)
+
+#### Local Home Assistant add-on image test
+
+After changing the `Dockerfile`, the Home Assistant add-on image can be checked locally with BuildKit:
+
+```sh
+docker buildx build --check .
+docker buildx build --load --tag addon-warema-bridge:local --platform linux/amd64 .
+docker run --rm --entrypoint node addon-warema-bridge:local --check /srv/bridge.js
+docker run --rm --entrypoint node addon-warema-bridge:local -e "require('serialport'); console.log('serialport ok')"
+docker run --rm --entrypoint sh addon-warema-bridge:local -c "command -v g++; command -v make"
+```
+
+The last command should print nothing and exit with code `1`. This is expected and confirms that the build tools `g++` and `make` are not part of the final runtime image.
+
+For ARM64, use `linux/aarch64` instead of `linux/amd64`. The full add-on startup with MQTT, `/data/options.json`, and a real USB dongle should still be tested in Home Assistant or a matching local environment.
 
 #### Local development
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,14 +1,12 @@
 ---
 name: Warema WMS Bridge
-version: "2.1.4"
+version: "2.1.5"
 slug: addon-warema-bridge
 description: "Bridge for Warema WMS devices with MQTT support"
 url: "https://github.com/chha25/addon-warema-bridge"
 arch:
   - aarch64
   - amd64
-  - armv7
-  - i386
 startup: "services"
 boot: "auto"
 init: false

--- a/repository.json
+++ b/repository.json
@@ -4,5 +4,5 @@
   "maintainer": "chha25",
   "slug": "addon-warema-bridge",
   "type": "addon",
-  "version": "2.1.4"
+  "version": "2.1.5"
 }


### PR DESCRIPTION
## Summary

- Update the Home Assistant add-on Dockerfile for the current BuildKit-based build flow by using `ghcr.io/home-assistant/base:latest` directly.
- Remove temporary native build tools from the runtime image after installing production dependencies.
- Limit supported add-on architectures to `amd64` and `aarch64`.
- Prepare release `2.1.5` and document local add-on image validation steps.
- Translate the changelog to English so the GitHub release body is English as well.

## Root cause

Home Assistant Supervisor builds no longer pass an external `BUILD_FROM` value in the same way. The old `FROM $BUILD_FROM` line could therefore resolve to an empty base image and fail during installation.

## Validation

- `npm run lint`
- `npm run build`
- `npm run smoke`
- `npm test -- --runInBand`
- `docker buildx build --check .`
- `docker buildx build --load --tag addon-warema-bridge:local --platform linux/amd64 .`
- Runtime image checks for `/srv/bridge.js`, `serialport`, and removed `g++`/`make` build tools