### PR TITLE
Add Weather Station Pro support and MQTT weather sensors with discovery and state publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this Home Assistant add-on are documented in this file.
 
+## 3.0.2
+
+- Fix #34: Added Weather Station Pro (device type `63`) support as a weather station so it is not registered as a blind.
+- MQTT Discovery: Weather stations now publish Home Assistant discovery for illuminance, temperature, wind speed, and rain.
+- MQTT runtime: Weather broadcasts now immediately publish sensor state updates, including wind speed and rain status.
+
 ## 3.0.1
 
 - Fix #30: Keep the existing WMS USB stick instance across MQTT reconnects so the serial connection is not reinitialized repeatedly.

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,8 @@ Diese Bridge bindet Warema-WMS-Geräte per MQTT in Home Assistant ein und ist mi
 ### Funktionen
 
 - Bindet Warema-WMS-Jalousien, Wetterstationen und weitere Geräte in Home Assistant ein.
+- Unterstützt Warema Weather Station Pro (Gerätetyp `63`) als Wetterstation.
+- Stellt Wetterwerte per MQTT Discovery als Home-Assistant-Sensoren bereit: Helligkeit, Temperatur, Windgeschwindigkeit und Regenstatus.
 - Kommunikation über MQTT (z. B. mit `core-mosquitto`).
 - Automatische Erkennung und Registrierung von Geräten.
 - Retained Discovery- und Availability-Topics für robustes Recovery nach Home-Assistant-Neustarts.
@@ -43,6 +45,19 @@ Passe die Optionen im Add-on an:
 | `wms_channel`     | WMS-Kanal                            | `17`                          |
 | `ignored_devices` | Kommagetrennte Geräte-IDs ignorieren | (leer)                        |
 | `force_devices`   | Kommagetrennte Geräte-IDs erzwingen  | (leer)                        |
+
+#### Wetterstationen
+
+Erkannte Warema-WMS-Wetterstationen, inklusive Weather Station Pro mit Gerätetyp `63`, werden nicht als Jalousien registriert. Stattdessen veröffentlicht die Bridge MQTT-Discovery-Nachrichten für Home Assistant und aktualisiert die Messwerte bei eingehenden Wetter-Broadcasts.
+
+Verfügbare Entitäten:
+
+| Entität | MQTT-State-Topic | Home-Assistant-Typ | Einheit / Werte |
+|---------|------------------|--------------------|-----------------|
+| Helligkeit | `warema/<serial>/illuminance/state` | Sensor | `lx` |
+| Temperatur | `warema/<serial>/temperature/state` | Sensor | `°C` |
+| Windgeschwindigkeit | `warema/<serial>/wind_speed/state` | Sensor | `m/s` |
+| Regen | `warema/<serial>/rain/state` | Binary Sensor | `ON` / `OFF` |
 
 #### Logging
 
@@ -129,6 +144,8 @@ This bridge integrates Warema WMS devices into Home Assistant via MQTT and is co
 ### Features
 
 - Integrates Warema WMS blinds, weather stations, and other devices into Home Assistant.
+- Supports Warema Weather Station Pro (device type `63`) as a weather station.
+- Exposes weather values through MQTT discovery as Home Assistant sensors: illuminance, temperature, wind speed, and rain status.
 - MQTT communication (e.g. with `core-mosquitto`).
 - Automatic device discovery and registration.
 - Retained discovery and availability topics for robust Home Assistant restart recovery.
@@ -165,6 +182,19 @@ Configure these add-on options:
 | `wms_channel`     | WMS channel                          | `17`                          |
 | `ignored_devices` | Comma-separated device IDs to ignore | (empty)                       |
 | `force_devices`   | Comma-separated device IDs to force  | (empty)                       |
+
+#### Weather stations
+
+Detected Warema WMS weather stations, including Weather Station Pro devices with device type `63`, are not registered as blinds. Instead, the bridge publishes MQTT discovery messages for Home Assistant and updates measurements whenever weather broadcasts are received.
+
+Available entities:
+
+| Entity | MQTT state topic | Home Assistant type | Unit / values |
+|--------|------------------|---------------------|---------------|
+| Illuminance | `warema/<serial>/illuminance/state` | Sensor | `lx` |
+| Temperature | `warema/<serial>/temperature/state` | Sensor | `°C` |
+| Wind speed | `warema/<serial>/wind_speed/state` | Sensor | `m/s` |
+| Rain | `warema/<serial>/rain/state` | Binary sensor | `ON` / `OFF` |
 
 #### Logging
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Warema WMS Bridge
-version: "3.0.1"
+version: "3.0.2"
 slug: addon-warema-bridge
 description: "Bridge for Warema WMS devices with MQTT support"
 url: "https://github.com/chha25/addon-warema-bridge"

--- a/repository.json
+++ b/repository.json
@@ -4,5 +4,5 @@
   "maintainer": "chha25",
   "slug": "addon-warema-bridge",
   "type": "addon",
-  "version": "3.0.1"
+  "version": "3.0.2"
 }

--- a/warema-bridge/rootfs/srv/__tests__/bridge.test.js
+++ b/warema-bridge/rootfs/srv/__tests__/bridge.test.js
@@ -190,7 +190,7 @@ describe('bridge.js', () => {
   test('callback should handle wms-vb-rcv-weather-broadcast for new station', () => {
     const msg = {
       topic: 'wms-vb-rcv-weather-broadcast',
-      payload: { weather: { snr: 999, lumen: 123, temp: 24 } }
+      payload: { weather: { snr: 999, lumen: 123, temp: 24, wind: 4, rain: false } }
     };
     callback(null, msg);
     expect(clientMock.publish).toHaveBeenCalledWith(
@@ -203,7 +203,46 @@ describe('bridge.js', () => {
       expect.any(String),
       { retain: true }
     );
+    expect(clientMock.publish).toHaveBeenCalledWith(
+      'homeassistant/sensor/999/wind_speed/config',
+      expect.any(String),
+      { retain: true }
+    );
+    expect(clientMock.publish).toHaveBeenCalledWith(
+      'homeassistant/binary_sensor/999/rain/config',
+      expect.any(String),
+      { retain: true }
+    );
+    expect(clientMock.publish).toHaveBeenCalledWith('warema/999/illuminance/state', '123');
+    expect(clientMock.publish).toHaveBeenCalledWith('warema/999/temperature/state', '24');
+    expect(clientMock.publish).toHaveBeenCalledWith('warema/999/wind_speed/state', '4');
+    expect(clientMock.publish).toHaveBeenCalledWith('warema/999/rain/state', 'OFF');
     expect(clientMock.publish).toHaveBeenCalledWith('warema/999/availability', 'online', { retain: true });
+  });
+
+  test('callback should register Weather Station Pro type 63 as weather device', () => {
+    callback(null, {
+      topic: 'wms-vb-scanned-devices',
+      payload: { devices: [{ snr: 1485190, type: 63 }] }
+    });
+
+    expect(stickUsbMock.vnBlindAdd).not.toHaveBeenCalledWith(1485190, '1485190');
+    expect(clientMock.publish).toHaveBeenCalledWith(
+      'homeassistant/sensor/1485190/wind_speed/config',
+      expect.any(String),
+      { retain: true }
+    );
+    expect(clientMock.publish).toHaveBeenCalledWith(
+      'homeassistant/binary_sensor/1485190/rain/config',
+      expect.any(String),
+      { retain: true }
+    );
+
+    const discoveryCall = clientMock.publish.mock.calls.find(
+      ([topic]) => topic === 'homeassistant/sensor/1485190/wind_speed/config'
+    );
+    const payload = JSON.parse(discoveryCall[1]);
+    expect(payload.device.model).toBe('Weather Station Pro');
   });
 
   test('callback should handle wms-vb-scanned-devices', () => {

--- a/warema-bridge/rootfs/srv/bridge.js
+++ b/warema-bridge/rootfs/srv/bridge.js
@@ -23,6 +23,12 @@ const DEVICE_TYPES = {
   PLUG_RECEIVER: 20,
   ACTUATOR_UP: 21,
   VERTICAL_AWNING: 25,
+  WEATHER_STATION_PRO: 63,
+};
+
+const DEVICE_CATEGORIES = {
+  SHADE: 'shade',
+  WEATHER: 'weather',
 };
 
 const POSITION_UPDATE_INTERVAL_MS = 30000;
@@ -116,12 +122,14 @@ const settingsPar = {
 };
 
 const registeredShades = new Set();
+const registeredWeatherStations = new Set();
 const registeredBlindsInLibrary = new Set();
 const shadePosition = {};
 let mqttConnectCount = 0;
 
 const resetLocalRegistrationState = () => {
   registeredShades.clear();
+  registeredWeatherStations.clear();
   registeredBlindsInLibrary.clear();
   Object.keys(shadePosition).forEach((serialNumber) => {
     delete shadePosition[serialNumber];
@@ -152,6 +160,13 @@ const handleHomeAssistantOnline = () => {
 
 const buildAvailabilityTopic = (serialNumber) => `warema/${serialNumber}/availability`;
 const buildCoverConfigTopic = (serialNumber) => `homeassistant/cover/${serialNumber}/${serialNumber}/config`;
+const buildSensorConfigTopic = (serialNumber, sensorName) => (
+  `homeassistant/sensor/${serialNumber}/${sensorName}/config`
+);
+const buildBinarySensorConfigTopic = (serialNumber, sensorName) => (
+  `homeassistant/binary_sensor/${serialNumber}/${sensorName}/config`
+);
+const buildWeatherStateTopic = (serialNumber, sensorName) => `warema/${serialNumber}/${sensorName}/state`;
 const buildStateTopic = (serialNumber) => `warema/${serialNumber}/state`;
 
 const createBasePayload = (serialNumber) => ({
@@ -209,23 +224,17 @@ const createShadingPayload = (serialNumber, model, supportsTilt) => ({
 const getPayloadByDeviceType = (serialNumber, type) => {
   switch (Number(type)) {
     case DEVICE_TYPES.WEATHER_STATION:
-      return {
-        payload: {
-          ...createBasePayload(serialNumber),
-          device: {
-            ...createBaseDevice(serialNumber),
-            model: 'Weather station',
-          },
-        },
-      };
+      return { category: DEVICE_CATEGORIES.WEATHER, model: 'Weather Station' };
     case DEVICE_TYPES.WEBCONTROL_PRO:
       return null;
+    case DEVICE_TYPES.WEATHER_STATION_PRO:
+      return { category: DEVICE_CATEGORIES.WEATHER, model: 'Weather Station Pro' };
     case DEVICE_TYPES.PLUG_RECEIVER:
-      return { payload: createShadingPayload(serialNumber, 'Plug receiver', true) };
+      return { category: DEVICE_CATEGORIES.SHADE, payload: createShadingPayload(serialNumber, 'Plug receiver', true) };
     case DEVICE_TYPES.ACTUATOR_UP:
-      return { payload: createShadingPayload(serialNumber, 'Actuator UP', true) };
+      return { category: DEVICE_CATEGORIES.SHADE, payload: createShadingPayload(serialNumber, 'Actuator UP', true) };
     case DEVICE_TYPES.VERTICAL_AWNING:
-      return { payload: createShadingPayload(serialNumber, 'Vertical awning', false) };
+      return { category: DEVICE_CATEGORIES.SHADE, payload: createShadingPayload(serialNumber, 'Vertical awning', false) };
     default:
       log('warning', `Unrecognized device type: ${type}`);
       return null;
@@ -241,7 +250,6 @@ const registerShade = (serialNumber) => {
 
 function registerDevice(element) {
   const serialNumber = element.snr.toString();
-  const configTopic = buildCoverConfigTopic(serialNumber);
 
   log('debug', `Registering ${serialNumber}`);
 
@@ -250,14 +258,24 @@ function registerDevice(element) {
     return;
   }
 
-  if (ignoredDevices.includes(serialNumber)) {
-    log('info', `Ignoring and removing device ${serialNumber} (type ${element.type})`);
+  const isIgnored = ignoredDevices.includes(serialNumber);
+  if (isIgnored) {
+    log('info', `Ignoring device ${serialNumber} (type ${element.type})`);
   } else {
     log('info', `Adding device ${serialNumber} (type ${element.type})`);
-    registerShade(serialNumber);
   }
 
-  client.publish(configTopic, JSON.stringify(deviceConfig.payload), { retain: true });
+  if (deviceConfig.category === DEVICE_CATEGORIES.WEATHER) {
+    if (!isIgnored) {
+      publishWeatherDiscovery({ snr: serialNumber }, deviceConfig.model);
+    }
+    return;
+  }
+
+  if (!isIgnored) {
+    registerShade(serialNumber);
+  }
+  client.publish(buildCoverConfigTopic(serialNumber), JSON.stringify(deviceConfig.payload), { retain: true });
 }
 
 function registerDevices() {
@@ -272,58 +290,104 @@ function registerDevices() {
   stickUsb.scanDevices({ autoAssignBlinds: false });
 }
 
-const publishWeatherDiscovery = (weather) => {
+const WEATHER_SENSORS = [
+  {
+    name: 'illuminance',
+    component: 'sensor',
+    stateKey: 'lumen',
+    deviceClass: 'illuminance',
+    unitOfMeasurement: 'lx',
+  },
+  {
+    name: 'temperature',
+    component: 'sensor',
+    stateKey: 'temp',
+    deviceClass: 'temperature',
+    unitOfMeasurement: '°C',
+  },
+  {
+    name: 'wind_speed',
+    component: 'sensor',
+    stateKey: 'wind',
+    deviceClass: 'wind_speed',
+    unitOfMeasurement: 'm/s',
+  },
+  {
+    name: 'rain',
+    component: 'binary_sensor',
+    stateKey: 'rain',
+    deviceClass: 'moisture',
+  },
+];
+
+const buildWeatherDiscoveryTopic = (serialNumber, sensor) => (
+  sensor.component === 'binary_sensor'
+    ? buildBinarySensorConfigTopic(serialNumber, sensor.name)
+    : buildSensorConfigTopic(serialNumber, sensor.name)
+);
+
+const createWeatherSensorPayload = (serialNumber, sensor, basePayload) => ({
+  ...basePayload,
+  state_topic: buildWeatherStateTopic(serialNumber, sensor.name),
+  device_class: sensor.deviceClass,
+  unique_id: `${serialNumber}_${sensor.name}`,
+  ...(sensor.unitOfMeasurement ? { unit_of_measurement: sensor.unitOfMeasurement } : {}),
+  ...(sensor.component === 'sensor' ? { state_class: 'measurement' } : {}),
+  ...(sensor.component === 'binary_sensor' ? { payload_on: 'ON', payload_off: 'OFF' } : {}),
+});
+
+const publishWeatherDiscovery = (weather, model = 'Weather Station') => {
   const serialNumber = weather.snr.toString();
   const availabilityTopic = buildAvailabilityTopic(serialNumber);
   const basePayload = {
-    name: serialNumber,
-    availability: [{ topic: MQTT_TOPICS.bridgeState }, { topic: availabilityTopic }],
+    ...createBasePayload(serialNumber),
     device: {
-      identifiers: serialNumber,
-      manufacturer: 'Warema',
-      model: 'Weather Station',
-      name: serialNumber,
+      ...createBaseDevice(serialNumber),
+      model,
     },
     force_update: true,
   };
 
-  client.publish(
-    `homeassistant/sensor/${serialNumber}/illuminance/config`,
-    JSON.stringify({
-      ...basePayload,
-      state_topic: `warema/${serialNumber}/illuminance/state`,
-      device_class: 'illuminance',
-      unique_id: `${serialNumber}_illuminance`,
-      unit_of_measurement: 'lm',
-    }),
-    { retain: true },
-  );
-
-  client.publish(
-    `homeassistant/sensor/${serialNumber}/temperature/config`,
-    JSON.stringify({
-      ...basePayload,
-      state_topic: `warema/${serialNumber}/temperature/state`,
-      device_class: 'temperature',
-      unique_id: `${serialNumber}_temperature`,
-      unit_of_measurement: 'C',
-    }),
-    { retain: true },
-  );
+  WEATHER_SENSORS.forEach((sensor) => {
+    client.publish(
+      buildWeatherDiscoveryTopic(serialNumber, sensor),
+      JSON.stringify(createWeatherSensorPayload(serialNumber, sensor, basePayload)),
+      { retain: true },
+    );
+  });
 
   client.publish(availabilityTopic, 'online', { retain: true });
-  registeredShades.add(serialNumber);
+  registeredWeatherStations.add(serialNumber);
+};
+
+const normalizeWeatherValue = (sensor, value) => {
+  if (sensor.component === 'binary_sensor') {
+    return value ? 'ON' : 'OFF';
+  }
+
+  return value.toString();
+};
+
+const publishWeatherStates = (serialNumber, weather) => {
+  WEATHER_SENSORS.forEach((sensor) => {
+    if (typeof weather[sensor.stateKey] === 'undefined' || weather[sensor.stateKey] === null) {
+      return;
+    }
+
+    client.publish(
+      buildWeatherStateTopic(serialNumber, sensor.name),
+      normalizeWeatherValue(sensor, weather[sensor.stateKey]),
+    );
+  });
 };
 
 const handleWeatherBroadcast = (weather) => {
   const serialNumber = weather.snr.toString();
-  if (registeredShades.has(serialNumber)) {
-    client.publish(`warema/${serialNumber}/illuminance/state`, weather.lumen.toString());
-    client.publish(`warema/${serialNumber}/temperature/state`, weather.temp.toString());
-    return;
+  if (!registeredWeatherStations.has(serialNumber)) {
+    publishWeatherDiscovery(weather);
   }
 
-  publishWeatherDiscovery(weather);
+  publishWeatherStates(serialNumber, weather);
 };
 
 const publishShadeState = (serialNumber, state) => {


### PR DESCRIPTION
### Motivation
- Add support for weather devices (including Weather Station Pro type `63`) and expose their measurements to Home Assistant via MQTT discovery.
- Ensure weather broadcasts immediately publish sensor state updates (illuminance, temperature, wind speed, rain) at runtime instead of registering them as blinds.
- Keep existing shade/blind registration flow intact while separating weather device registration and availability handling.

### Description
- Introduced `DEVICE_TYPES.WEATHER_STATION_PRO`, `DEVICE_CATEGORIES`, and a `registeredWeatherStations` set and adjusted `registerDevice` to treat weather devices separately from shades.
- Added `WEATHER_SENSORS` metadata plus helper functions and builders (`publishWeatherDiscovery`, `publishWeatherStates`, `normalizeWeatherValue`, `buildWeatherDiscoveryTopic`, `buildWeatherStateTopic`) to publish Home Assistant discovery payloads and runtime states for illuminance, temperature, wind speed, and rain.
- Updated `handleWeatherBroadcast` to publish discovery for new weather stations and to publish normalized sensor states immediately on broadcasts.
- Bumped add-on `version` to `3.0.2` in `config.yaml` and `repository.json`, updated `CHANGELOG.md`, and extended Jest tests in `warema-bridge/rootfs/srv/__tests__/bridge.test.js` to cover discovery, state publishing, and Weather Station Pro behavior.

### Testing
- Ran the Jest unit test suite with updated `bridge.test.js` covering weather discovery, publish of sensor states, and Device Pro registration, and the tests passed.
- Existing MQTT cover and movement-related tests were executed as part of the test run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e685be5883288aa9a2002ab9e7e1)