### PR TITLE
Normalize Weather Station Pro wind values and parse comma-decimal inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this Home Assistant add-on are documented in this file.
 
+## 3.0.3
+
+- Fix #36: Weather Station Pro wind normalization now robustly handles decimal wind values from weather broadcasts.
+- MQTT runtime: Wind values are now parsed from numbers and strings (including comma decimals like `"4,5"`) before Weather Station Pro scaling is applied.
+- Tests: Added coverage for type `63` wind normalization with integer and comma-decimal input values.
+
 ## 3.0.2
 
 - Fix #34: Added Weather Station Pro (device type `63`) support as a weather station so it is not registered as a blind.

--- a/warema-bridge/rootfs/srv/__tests__/bridge.test.js
+++ b/warema-bridge/rootfs/srv/__tests__/bridge.test.js
@@ -245,6 +245,36 @@ describe('bridge.js', () => {
     expect(payload.device.model).toBe('Weather Station Pro');
   });
 
+
+  test('callback should publish halved wind speed for Weather Station Pro broadcasts', () => {
+    callback(null, {
+      topic: 'wms-vb-scanned-devices',
+      payload: { devices: [{ snr: 1485190, type: 63 }] }
+    });
+
+    callback(null, {
+      topic: 'wms-vb-rcv-weather-broadcast',
+      payload: { weather: { snr: 1485190, wind: 4 } }
+    });
+
+    expect(clientMock.publish).toHaveBeenCalledWith('warema/1485190/wind_speed/state', '2');
+  });
+
+
+  test('callback should normalize Weather Station Pro wind values with decimals and comma strings', () => {
+    callback(null, {
+      topic: 'wms-vb-scanned-devices',
+      payload: { devices: [{ snr: 1485190, type: 63 }] }
+    });
+
+    callback(null, {
+      topic: 'wms-vb-rcv-weather-broadcast',
+      payload: { weather: { snr: 1485190, wind: '4,5' } }
+    });
+
+    expect(clientMock.publish).toHaveBeenCalledWith('warema/1485190/wind_speed/state', '2.25');
+  });
+
   test('callback should handle wms-vb-scanned-devices', () => {
     const msg = { topic: 'wms-vb-scanned-devices', payload: { devices: [{ snr: 222, type: 25 }] } };
     callback(null, msg);

--- a/warema-bridge/rootfs/srv/bridge.js
+++ b/warema-bridge/rootfs/srv/bridge.js
@@ -124,6 +124,7 @@ const settingsPar = {
 const registeredShades = new Set();
 const registeredWeatherStations = new Set();
 const registeredBlindsInLibrary = new Set();
+const registeredWeatherStationTypes = new Map();
 const shadePosition = {};
 let mqttConnectCount = 0;
 
@@ -131,6 +132,7 @@ const resetLocalRegistrationState = () => {
   registeredShades.clear();
   registeredWeatherStations.clear();
   registeredBlindsInLibrary.clear();
+  registeredWeatherStationTypes.clear();
   Object.keys(shadePosition).forEach((serialNumber) => {
     delete shadePosition[serialNumber];
   });
@@ -266,6 +268,7 @@ function registerDevice(element) {
   }
 
   if (deviceConfig.category === DEVICE_CATEGORIES.WEATHER) {
+    registeredWeatherStationTypes.set(serialNumber, Number(element.type));
     if (!isIgnored) {
       publishWeatherDiscovery({ snr: serialNumber }, deviceConfig.model);
     }
@@ -360,9 +363,43 @@ const publishWeatherDiscovery = (weather, model = 'Weather Station') => {
   registeredWeatherStations.add(serialNumber);
 };
 
-const normalizeWeatherValue = (sensor, value) => {
+const parseNumericWeatherValue = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().replace(',', '.');
+    if (!normalized) {
+      return null;
+    }
+
+    const parsed = Number.parseFloat(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const normalizeWindValue = (serialNumber, value) => {
+  const numericValue = parseNumericWeatherValue(value);
+  if (numericValue === null) {
+    return value.toString();
+  }
+
+  const isWeatherStationPro = registeredWeatherStationTypes.get(serialNumber) === DEVICE_TYPES.WEATHER_STATION_PRO;
+  const normalizedValue = isWeatherStationPro ? numericValue / 2 : numericValue;
+
+  return normalizedValue.toString();
+};
+
+const normalizeWeatherValue = (serialNumber, sensor, value) => {
   if (sensor.component === 'binary_sensor') {
     return value ? 'ON' : 'OFF';
+  }
+
+  if (sensor.stateKey === 'wind') {
+    return normalizeWindValue(serialNumber, value);
   }
 
   return value.toString();
@@ -376,7 +413,7 @@ const publishWeatherStates = (serialNumber, weather) => {
 
     client.publish(
       buildWeatherStateTopic(serialNumber, sensor.name),
-      normalizeWeatherValue(sensor, weather[sensor.stateKey]),
+      normalizeWeatherValue(serialNumber, sensor, weather[sensor.stateKey]),
     );
   });
 };


### PR DESCRIPTION
### Motivation

- Make wind values from Weather Station Pro (device type `63`) robustly consumable by MQTT consumers by normalizing and scaling incoming wind data. 
- Accept numeric wind values sent as numbers or strings (including comma decimals like `"4,5"`) from weather broadcasts to avoid mis-parsing.
- Document the behavior in the `CHANGELOG.md` for release `3.0.3`.

### Description

- Track registered weather station device types using a `Map` called `registeredWeatherStationTypes` and clear it in `resetLocalRegistrationState`.
- Record device type when registering weather devices in `registerDevice` so device-specific normalization can be applied for Weather Station Pro (`63`).
- Add `parseNumericWeatherValue` to coerce numbers and numeric strings (including comma decimals) to `Number` or return `null` for invalid values, and add `normalizeWindValue` which divides wind by 2 for Weather Station Pro devices before returning a string.
- Update `normalizeWeatherValue` and `publishWeatherStates` to accept the `serialNumber` so wind normalization can be applied per-device, and include test and changelog updates.

### Testing

- Ran unit tests with `jest` and added two tests: `callback should publish halved wind speed for Weather Station Pro broadcasts` and `callback should normalize Weather Station Pro wind values with decimals and comma strings` that validate integer and comma-decimal wind inputs respectively, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c94bf4dc88328a741ffa7c1a9c4fc)